### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/src/apps/manage/pom.xml
+++ b/src/apps/manage/pom.xml
@@ -30,7 +30,7 @@
     <aspectjweaver.version>1.6.4</aspectjweaver.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-digester.version>2.0</commons-digester.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-httpclient.version>3.0</commons-httpclient.version>

--- a/src/apps/portal/pom.xml
+++ b/src/apps/portal/pom.xml
@@ -30,7 +30,7 @@
     <commons.io.version>1.4</commons.io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-beanutils.version>1.8.0</commons-beanutils.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <log4j.version>1.2.15</log4j.version>
     <slf4j.version>1.6.1</slf4j.version>
     <springframework.version>3.0.6.RELEASE</springframework.version>

--- a/src/apps/report/pom.xml
+++ b/src/apps/report/pom.xml
@@ -65,7 +65,7 @@
     <commons-beanutils.version>1.8.0</commons-beanutils.version>
     <commons-digester.version>2.0</commons-digester.version>
     <commons-cli.version>1.0</commons-cli.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <commons-pool.version>1.4</commons-pool.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>

--- a/src/modules/core/pom.xml
+++ b/src/modules/core/pom.xml
@@ -29,7 +29,7 @@
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-lang.version>2.4</commons-lang.version>
     <commons-beanutils.version>1.8.0</commons-beanutils.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <commons-httpclient.version>3.0</commons-httpclient.version>
     <springframework.version>3.0.6.RELEASE</springframework.version>

--- a/src/modules/hibernate/pom.xml
+++ b/src/modules/hibernate/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <commons-beanutils.version>1.8.0</commons-beanutils.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <springframework.version>3.0.6.RELEASE</springframework.version>
     <spring-security.version>3.0.6.RELEASE</spring-security.version>

--- a/src/modules/service/pom.xml
+++ b/src/modules/service/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <junit.version>4.7</junit.version>
     <commons-beanutils.version>1.8.0</commons-beanutils.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <aopalliance.version>1.0</aopalliance.version>
     <springframework.version>3.0.6.RELEASE</springframework.version>

--- a/src/modules/workflow/pom.xml
+++ b/src/modules/workflow/pom.xml
@@ -22,7 +22,7 @@
   </build>
 
   <properties>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <hibernate.version>3.6.10.Final</hibernate.version>
     <activiti.version>5.9</activiti.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -25,7 +25,7 @@
     <commons-logging.version>1.1.1</commons-logging.version>
     <commons-beanutils.version>1.8.0</commons-beanutils.version>
     <commons-digester.version>2.0</commons-digester.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.3</commons-codec.version>
     <commons-pool.version>1.4</commons-pool.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
